### PR TITLE
script/ptl-tool.py: Fixed detached from origin/master

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -121,13 +121,12 @@ def build_branch(args):
         log.info("Detaching HEAD onto base: {}".format(base))
         try:
             base_path = args.base_path + base
-            base = filter(lambda r: r.path == base_path, G.refs)[0]
         except IndexError:
             log.error("Branch base does not exist!")
             sys.exit(1)
 
         # So we know that we're not on an old test branch, detach HEAD onto ref:
-        base.checkout()
+        git.Git().checkout(base)
 
     for pr in args.prs:
         log.info("Merging PR #{pr}".format(pr=pr))


### PR DESCRIPTION
The following command always leaves "detached from origin/master"
    
$ env PTL_TOOL_BASE_PATH=refs/remotes/upstream/ src/script/ptl-tool.py --base master 1234567 2345678
    
Signed-off-by: Jos Collin <jcollin@redhat.com>